### PR TITLE
Decoupling receive loop from message processing

### DIFF
--- a/Common/CosmosDuplexPipe.cs
+++ b/Common/CosmosDuplexPipe.cs
@@ -83,7 +83,7 @@ using Microsoft.Azure.Cosmos.Core.Trace;
             string itemName,
             string partitionKey)
         {
-            FlushResult flushResult = await this.SendReadRequestAsync(replicaPath, databaseName, contaienrName, itemName, partitionKey);
+            await this.SendReadRequestAsync(replicaPath, databaseName, contaienrName, itemName, partitionKey);
 
             (UInt32 messageLength, byte[] messageBytes) = await this.Reader.MoveNextAsync(isLengthCountedIn: true);
 
@@ -111,7 +111,7 @@ using Microsoft.Azure.Cosmos.Core.Trace;
             ArrayPool<byte>.Shared.Return(messageBytes);
         }
 
-        public ValueTask<FlushResult> SendReadRequestAsync(
+        public ValueTask SendReadRequestAsync(
             string replicaPath, 
             string databaseName, 
             string contaienrName,
@@ -278,7 +278,7 @@ using Microsoft.Azure.Cosmos.Core.Trace;
             await RntbdConstants.ConnectionContextResponse.Serialize(200, Guid.NewGuid(), this.Writer.PipeWriter);
         }
 
-        private ValueTask<FlushResult> SendRntbdContext(
+        private ValueTask SendRntbdContext(
             bool enableChannelMultiplexing = true)
         {
             Guid activityId = Guid.NewGuid();

--- a/Common/LimitedPipeWriter.cs
+++ b/Common/LimitedPipeWriter.cs
@@ -26,7 +26,7 @@ namespace CosmosBenchmark
 
         public PipeWriter PipeWriter => this.pipeWriter;
 
-        public async ValueTask<FlushResult> GetMemoryAndFlushAsync(
+        public async ValueTask GetMemoryAndFlushAsync(
             int allocationLength,
             Action<Memory<byte>> actOnMemory,
             CancellationToken cancellationToken = default)
@@ -37,7 +37,11 @@ namespace CosmosBenchmark
                 Memory<byte> bytes = this.pipeWriter.GetMemory(allocationLength);
                 actOnMemory(bytes);
                 this.pipeWriter.Advance(allocationLength);
-                return await this.pipeWriter.FlushAsync();
+                await this.pipeWriter.FlushAsync();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("LimitedPipeWriter" + ex.ToString());
             }
             finally
             {

--- a/Common/LimitedPipeWriter.cs
+++ b/Common/LimitedPipeWriter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CosmosBenchmark
+{
+    internal class LimitedPipeWriter
+    {
+        private readonly PipeWriter pipeWriter;
+        private readonly SemaphoreSlim semaphore;
+
+        public LimitedPipeWriter(
+            PipeWriter pipeWriter,
+            int concurrencyLimit = 1)
+        {
+            this.pipeWriter = pipeWriter;
+            this.semaphore = new SemaphoreSlim(concurrencyLimit);
+        }
+
+        public PipeWriter PipeWriter => this.pipeWriter;
+
+        public async ValueTask<FlushResult> GetMemoryAndFlushAsync(
+            int allocationLength,
+            Action<Memory<byte>> actOnMemory,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await this.semaphore.WaitAsync(cancellationToken);
+                Memory<byte> bytes = this.pipeWriter.GetMemory(allocationLength);
+                actOnMemory(bytes);
+                this.pipeWriter.Advance(allocationLength);
+                return await this.pipeWriter.FlushAsync();
+            }
+            finally
+            {
+                this.semaphore.Release();
+            }
+        }
+    }
+}

--- a/Server/KestrelTcpDemo/BaseRntbd2ConnectionHandler.cs
+++ b/Server/KestrelTcpDemo/BaseRntbd2ConnectionHandler.cs
@@ -53,7 +53,7 @@ namespace KestrelTcpDemo
 
         internal static X509Certificate2 GetServerCertificate(string serverName)
         {
-            X509Store store = new X509Store("MY", StoreLocation.LocalMachine);
+            X509Store store = new X509Store("MY", StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
 
 
@@ -84,7 +84,6 @@ namespace KestrelTcpDemo
                     {
                         return cachedCert;
                     }
-
 
                     X509Certificate2 newCert = GetServerCertificate(hostName);
                     cachedCerts.TryAdd(hostName, newCert);

--- a/Server/KestrelTcpDemo/InMemoryRntbd2ConnectionHandler.cs
+++ b/Server/KestrelTcpDemo/InMemoryRntbd2ConnectionHandler.cs
@@ -132,11 +132,12 @@ namespace KestrelTcpDemo
             int totalResponselength = sizeof(UInt32) + sizeof(UInt32) + 16;
             totalResponselength += response.CalculateLength();
 
-            Memory<byte> bytes = cosmosDuplexPipe.Writer.GetMemory(totalResponselength);
-            int serializedLength = InMemoryRntbd2ConnectionHandler.Serialize(totalResponselength, 200, operationId, response, testPayload, bytes);
-
-            cosmosDuplexPipe.Writer.Advance(serializedLength);
-            await cosmosDuplexPipe.Writer.FlushAsync();
+            int serializedLength = 0;
+            await cosmosDuplexPipe.Writer.GetMemoryAndFlushAsync(totalResponselength,
+                (bytes) =>
+                {
+                    serializedLength = InMemoryRntbd2ConnectionHandler.Serialize(totalResponselength, 200, operationId, response, testPayload, bytes);
+                });
 
             return serializedLength;
         }

--- a/Server/KestrelTcpDemo/KestrelTcpDemo.csproj
+++ b/Server/KestrelTcpDemo/KestrelTcpDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <DefineConstants>$(DefineConstants)TRACE;COSMOSCLIENT</DefineConstants>

--- a/Server/KestrelTcpDemo/KestrelTcpDemo.csproj
+++ b/Server/KestrelTcpDemo/KestrelTcpDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <DefineConstants>$(DefineConstants)TRACE;COSMOSCLIENT</DefineConstants>

--- a/Server/KestrelTcpDemo/Program.cs
+++ b/Server/KestrelTcpDemo/Program.cs
@@ -25,41 +25,41 @@ namespace KestrelTcpDemo
                         // This shows how a custom framework could plug in an experience without using Kestrel APIs directly
                         if (args != null && args.Length > 0)
                         {
-                            services.AddFramework(new IPEndPoint(IPAddress.Any, 8009), args[0]);
+                            services.AddFramework(new IPEndPoint(IPAddress.Loopback, 8009), args[0]);
                         }
                         else
                         {
-                            services.AddFramework(new IPEndPoint(IPAddress.Any, 8009), null);
+                            services.AddFramework(new IPEndPoint(IPAddress.Loopback, 8009), null);
                         }
                     })
                 .UseKestrel(options =>
                     {
-                        options.ListenAnyIP(7070, listenOptions =>
-                            {
-                                listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1;
+                        //options.ListenAnyIP(7070, listenOptions =>
+                        //    {
+                        //        listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1;
 
-                                if (args != null && args.Length > 0)
-                                {
-                                    listenOptions.UseHttps(StoreName.My, args[0], true, StoreLocation.LocalMachine);
-                                }
-                                else
-                                {
-                                    listenOptions.UseHttps();
-                                }
-                            });
+                        //        if (args != null && args.Length > 0)
+                        //        {
+                        //            listenOptions.UseHttps(StoreName.My, args[0], true, StoreLocation.LocalMachine);
+                        //        }
+                        //        else
+                        //        {
+                        //            listenOptions.UseHttps();
+                        //        }
+                        //    });
 
-                        options.ListenAnyIP(8080, listenOptions =>
-                            {
-                                listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2;
-                                if (args != null && args.Length > 0)
-                                {
-                                    listenOptions.UseHttps(StoreName.My, args[0], true, StoreLocation.LocalMachine);
-                                }
-                                else
-                                {
-                                    listenOptions.UseHttps();
-                                }
-                            });
+                        //options.ListenAnyIP(8080, listenOptions =>
+                        //    {
+                        //        listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2;
+                        //        if (args != null && args.Length > 0)
+                        //        {
+                        //            listenOptions.UseHttps(StoreName.My, args[0], true, StoreLocation.LocalMachine);
+                        //        }
+                        //        else
+                        //        {
+                        //            listenOptions.UseHttps();
+                        //        }
+                        //    });
 
                         // HTTP3
                         //options.ListenLocalhost(9090,


### PR DESCRIPTION
1. Receive message and extract complete information
2. Open connection to replica and start 1 receive loop for it independent from other replicas
3. Send request to replica and go back to loop of 1
4. Once the replica receive loop has anything (any response from the backend replica), write it back on the PipeWriter towards the SDK client